### PR TITLE
Fix armhf segfault in error message handling

### DIFF
--- a/src/protocol/pool_proto_modules.c
+++ b/src/protocol/pool_proto_modules.c
@@ -3139,7 +3139,7 @@ void per_node_error_log(POOL_CONNECTION_POOL *backend, int node_id, char *query,
 	POOL_CONNECTION_POOL_SLOT *slot = backend->slots[node_id];
 	char *message;
 
-	if (pool_extract_error_message(true, CONNECTION(backend, node_id), MAJOR(backend), true, &message) > 0)
+	if (pool_extract_error_message(true, CONNECTION(backend, node_id), MAJOR(backend), true, &message) == 1)
 	{
 		ereport(LOG,
 			(errmsg("%s: DB node id: %d backend pid: %d statement: \"%s\" message: \"%s\"",


### PR DESCRIPTION
On armhf the return value of an error to get a message gets read as
value 255 which qualifies as >0. But going on the message pointer has
a value of 0x25000000 and later on segfaults when trying to access that.

Fixes #14

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>