### PR TITLE
Fix pool processing reporting typo

### DIFF
--- a/src/utils/pool_process_reporting.c
+++ b/src/utils/pool_process_reporting.c
@@ -288,7 +288,7 @@ get_config(int *nrows)
 
 	StrNCpy(status[i].name, "child_max_connections", POOLCONFIG_MAXNAMELEN);
 	snprintf(status[i].value, POOLCONFIG_MAXVALLEN, "%d", pool_config->child_max_connections);
-	StrNCpy(status[i].desc, "if max_connections received, chile exits", POOLCONFIG_MAXDESCLEN);
+	StrNCpy(status[i].desc, "if max_connections received, child exits", POOLCONFIG_MAXDESCLEN);
 	i++;
 
 	StrNCpy(status[i].name, "connection_life_time", POOLCONFIG_MAXNAMELEN);


### PR DESCRIPTION
Just a simple typo. Should be child not chile 🌶.