### PR TITLE
Replace Runtime.exec(String) with Runtime.exec(String[]) to avoid Java 21 deprecation warnings

### DIFF
--- a/src/test/regression/tests/005.jdbc/PgpoolTest.java
+++ b/src/test/regression/tests/005.jdbc/PgpoolTest.java
@@ -52,11 +52,16 @@ public abstract class PgpoolTest {
 
     public void check() {
 	try {
-	    String command_line = "diff -u expected/" + getTestName() + " result/" +
-		getTestName();
 	    Process proc;
 
-	    proc = Runtime.getRuntime().exec(command_line);
+	    proc = Runtime.getRuntime().exec(new String[]{
+	    	"diff",
+	    	"-u",
+	    	"expected/",
+	    	getTestName(),
+	    	"result/",
+	    	getTestName()
+	    });
 	    proc.waitFor();
 	    System.out.print(getTestName() + ": ");
 	    if (proc.exitValue() == 0)

--- a/src/test/regression/tests/005.jdbc/RunTest.java
+++ b/src/test/regression/tests/005.jdbc/RunTest.java
@@ -23,10 +23,11 @@ public class RunTest {
 	    String dbname = prop.getProperty("pgpooltest.dbname");
 
 	    // setup database
-	    String command_line = "psql -f prepare.sql";
-	    command_line = command_line + " -h " + host + " -p " + port +
-		" -U " + user + " " + dbname;
-	    Process proc = Runtime.getRuntime().exec(command_line);
+	    Process proc = Runtime.getRuntime().exec(new String[]{
+	    	"psql", "-f", "prepare.sql",
+	    	"-h", host, "-p ", port,
+	    	"-U", user, dbname
+	    });
 	    proc.waitFor();
 
 	    StringTokenizer tokenizer = new StringTokenizer(tests, " ");

--- a/src/test/regression/tests/005.jdbc/RunTest.java
+++ b/src/test/regression/tests/005.jdbc/RunTest.java
@@ -25,7 +25,7 @@ public class RunTest {
 	    // setup database
 	    Process proc = Runtime.getRuntime().exec(new String[]{
 	    	"psql", "-f", "prepare.sql",
-	    	"-h", host, "-p ", port,
+	    	"-h", host, "-p", port,
 	    	"-U", user, dbname
 	    });
 	    proc.waitFor();


### PR DESCRIPTION
When running pgpool2 tests with Java 21, jdbc tests output deprecation warning when compiling PgpoolTest.java and RunTest.java. 
```
javac -Xlint:deprecation ./src/test/regression/tests/005.jdbc/*.java
./src/test/regression/tests/005.jdbc/PgpoolTest.java:59: warning: [deprecation] exec(String) in Runtime has been deprecated
	    proc = Runtime.getRuntime().exec(command_line);
	                               ^
./src/test/regression/tests/005.jdbc/RunTest.java:29: warning: [deprecation] exec(String) in Runtime has been deprecated
	    Process proc = Runtime.getRuntime().exec(command_line);
	                                       ^
2 warnings
```
Replace  Runtime.exec(String) with Runtime.exec(String[]) to avoid Java 21 deprecation warnings.