### PR TITLE
pgpool2 fails to build with -Werror=implicit-function-declaration

### DIFF
--- a/c-library.m4
+++ b/c-library.m4
@@ -230,6 +230,9 @@ AC_DEFUN([PGAC_FUNC_SNPRINTF_LONG_LONG_INT_FORMAT],
 AC_CACHE_VAL(pgac_cv_snprintf_long_long_int_format,
 [for pgac_format in '%lld' '%qd' '%I64d'; do
 AC_TRY_RUN([#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 typedef long long int ac_int64;
 #define INT64_FORMAT "$pgac_format"
 

--- a/src/auth/pool_hba.c
+++ b/src/auth/pool_hba.c
@@ -52,6 +52,7 @@
 #include "protocol/pool_process_query.h"
 
 #ifdef USE_LDAP
+#define LDAP_DEPRECATED 1
 #include <ldap.h>
 #endif
 
@@ -168,6 +169,7 @@ static POOL_CONNECTION * pam_frontend_kludge;	/* Workaround for passing
 #endif							/* USE_PAM */
 
 #ifdef USE_LDAP
+#define LDAP_DEPRECATED 1
 #include <ldap.h>
 
 static POOL_STATUS CheckLDAPAuth(POOL_CONNECTION *frontend);

--- a/src/include/auth/pool_hba.h
+++ b/src/include/auth/pool_hba.h
@@ -30,6 +30,7 @@
 #include "pool.h"
 
 #ifdef USE_LDAP
+#define LDAP_DEPRECATED 1
 #include  <ldap.h>
 #endif
 


### PR DESCRIPTION
This MR adds missing headers and define so that function prototypes are included.

This is due to Ubuntu enabling -Werror=implict-function-declaration on armhf due to time_t transition[1]

[1] https://bugs.launchpad.net/ubuntu/+source/pgpool2/+bug/2055234