### PR TITLE
fix compiling issues for 32-bit targets

### DIFF
--- a/src/include/utils/json.h
+++ b/src/include/utils/json.h
@@ -316,5 +316,6 @@ int			json_get_int_value_for_key(json_value *source, const char *key, int *value
 int			json_get_long_value_for_key(json_value *source, const char *key, long *value);
 char	   *json_get_string_value_for_key(json_value *source, const char *key);
 int			json_get_bool_value_for_key(json_value *source, const char *key, bool *value);
+int                    json_get_time_value_for_key(json_value * source, const char *key, time_t *value);
 
 #endif

--- a/src/parser/snprintf.c
+++ b/src/parser/snprintf.c
@@ -36,6 +36,7 @@
 #include "c.h"
 #endif
 
+#include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -1223,3 +1223,17 @@ json_get_string_value_for_key(json_value *source, const char *key)
 		return NULL;
 	return jNode->u.string.ptr;
 }
+
+int   
+json_get_time_value_for_key(json_value * source, const char *key, time_t *value)
+{
+	json_value *jNode;
+
+	jNode = json_get_value_for_key(source, key);
+	if (jNode == NULL)
+		return -1;
+	if (jNode->type != json_integer)
+		return -1;
+	*value = jNode->u.integer;
+	return 0;
+}

--- a/src/watchdog/wd_json_data.c
+++ b/src/watchdog/wd_json_data.c
@@ -540,7 +540,7 @@ get_watchdog_node_from_json(char *json_data, int data_len, char **authkey)
 	if (root == NULL || root->type != json_object)
 		goto ERROR_EXIT;
 
-	if (json_get_long_value_for_key(root, "StartupTimeSecs", &wdNode->startup_time.tv_sec))
+	if (json_get_time_value_for_key(root, "StartupTimeSecs", &wdNode->startup_time.tv_sec))
 	{
 		bool		escalated;
 		long		seconds_since_node_startup;


### PR DESCRIPTION
Hello,

I was trying to compile pgpool2 for 32-bit target (arm and x86) with gcc15,
and found two failures:

- the compiler was complaining about undefined isnan and ininf functions in
  snprintf.c file
- the compiler was also complaining about the size of timespec.tv_sec, which
  frequently differs on 32-bit targets from 64-bit ones

These two patches are aimed to fix these issues.


PS: I tried to subscribe to the mailing list, but it was frequently throwing 504 errors. When I finally managed to subscribe, and I sent the patches there, the emails rejected automatically.