### PR TITLE
Fix parallel build

### DIFF
--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -30,8 +30,15 @@ ARFLAGS = cr
 
 AM_YFLAGS = -d -Wno-yacc
 
-gram.c: gram.y scan.c
-gram_minimal.c: gram_minimal.y scan.c
+BUILT_SOURCES = \
+	gram.c \
+	gram.h \
+	gram_minimal.c \
+	gram_minimal.h \
+	scan.c
+
+gram.c gram.h: gram.y scan.c
+gram_minimal.c gram_minimal.h: gram_minimal.y scan.c
 
 scan.c: scan.l
 	$(LEX) -o'scan.c' $<


### PR DESCRIPTION
Added `BUILT_SOURCES` for gram.c, gram.h, gram_minimal.c, gram_minimal.h and scan.c to ensure that bison generated files are built before compilation of dependent C files (when parallelisation is enabled using `make -j`).